### PR TITLE
Multi onesky projects for translations

### DIFF
--- a/Command/CheckTranslationProgressCommand.php
+++ b/Command/CheckTranslationProgressCommand.php
@@ -49,17 +49,19 @@ class CheckTranslationProgressCommand extends ContainerAwareCommand
         $projectsIds = array_keys($this->getContainer()->getParameter('openclassrooms_onesky.file_paths'));
         $output->writeln('<info>Check translations progress</info>');
         $languages = [];
-        foreach ($projectsIds as $projectId)
-        $languages += $this->getContainer()
-            ->get('openclassrooms.onesky.services.language_service')
-            ->getLanguages($projectId, $input->getOption('locale'));
+        foreach ($projectsIds as $projectId) {
+            $projectLanguages = $this->getContainer()
+                ->get('openclassrooms.onesky.services.language_service')
+                ->getLanguages($projectId, $input->getOption('locale'));
+            $languages = array_merge($languages, $projectLanguages);
+        }
         $table = new Table($output);
         $table
-            ->setHeaders(['Locale', 'Progression'])
+            ->setHeaders(['Project', 'Locale', 'Progression'])
             ->setRows(
                 array_map(
                     function (Language $language) {
-                        return [$language->getLocale()." ".$language->getProjectId(), $language->getTranslationProgress()];
+                        return [$language->getProjectId(), $language->getLocale(), $language->getTranslationProgress()];
                     },
                     $languages
                 )

--- a/Command/CheckTranslationProgressCommand.php
+++ b/Command/CheckTranslationProgressCommand.php
@@ -46,17 +46,20 @@ class CheckTranslationProgressCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $projectsIds = array_keys($this->getContainer()->getParameter('openclassrooms_onesky.file_paths'));
         $output->writeln('<info>Check translations progress</info>');
-        $languages = $this->getContainer()
+        $languages = [];
+        foreach ($projectsIds as $projectId)
+        $languages += $this->getContainer()
             ->get('openclassrooms.onesky.services.language_service')
-            ->getLanguages($input->getOption('locale'));
+            ->getLanguages($projectId, $input->getOption('locale'));
         $table = new Table($output);
         $table
             ->setHeaders(['Locale', 'Progression'])
             ->setRows(
                 array_map(
                     function (Language $language) {
-                        return [$language->getLocale(), $language->getTranslationProgress()];
+                        return [$language->getLocale()." ".$language->getProjectId(), $language->getTranslationProgress()];
                     },
                     $languages
                 )

--- a/Command/Command.php
+++ b/Command/Command.php
@@ -49,7 +49,7 @@ abstract class Command extends ContainerAwareCommand
         $dispatcher->addListener(
             TranslationPrePullEvent::getEventName(),
             function (TranslationPrePullEvent $event) use ($output) {
-                $output->writeln('<info>Pulling for project id '.$this->getProjectId()."</info>\n");
+                $output->writeln("<info>Pulling files </info>\n");
                 $this->progressBar = new ProgressBar($output, $event->getExportFilesCount());
                 $this->progressBar->setFormat(PROGRESS_BAR_FORMAT);
                 $this->getProgressBar()->start();
@@ -88,14 +88,6 @@ abstract class Command extends ContainerAwareCommand
     }
 
     /**
-     * @return string
-     */
-    private function getProjectId()
-    {
-        return $this->getContainer()->getParameter('openclassrooms_onesky.project_id');
-    }
-
-    /**
      * @return ProgressBar
      */
     private function getProgressBar()
@@ -109,7 +101,7 @@ abstract class Command extends ContainerAwareCommand
         $dispatcher->addListener(
             TranslationPrePushEvent::getEventName(),
             function (TranslationPrePushEvent $event) use ($output) {
-                $output->writeln('<info>Pushing for project id '.$this->getProjectId()."</info>\n");
+                $output->writeln("<info>Pushing files </info>\n");
                 $this->progressBar = new ProgressBar($output, $event->getUploadFilesCount());
                 $this->progressBar->setFormat(PROGRESS_BAR_FORMAT);
                 $this->getProgressBar()->start();

--- a/Command/Command.php
+++ b/Command/Command.php
@@ -73,11 +73,11 @@ abstract class Command extends ContainerAwareCommand
                 $output->writeln('<info>'.count($event->getDownloadedFiles()).' files downloaded. </info>');
                 $table = new Table($output);
                 $table
-                    ->setHeaders(['File', 'Locale'])
+                    ->setHeaders(['Project', 'File', 'Locale'])
                     ->setRows(
                         array_map(
                             function (ExportFile $file) {
-                                return [$file->getSourceFilePathRelativeToProject(), $file->getRequestedLocale()];
+                                return [$file->getProjectId(), $file->getSourceFilePathRelativeToProject(), $file->getRequestedLocale()];
                             },
                             $event->getDownloadedFiles()
                         )
@@ -124,11 +124,11 @@ abstract class Command extends ContainerAwareCommand
                 $output->writeln('<info>'.count($event->getUploadedFiles()).' files downloaded. </info>');
                 $table = new Table($output);
                 $table
-                    ->setHeaders(['File', 'Locale'])
+                    ->setHeaders(['Project', 'File', 'Locale'])
                     ->setRows(
                         array_map(
                             function (UploadFile $file) {
-                                return [$file->getSourceFilePathRelativeToProject(), $file->getSourceLocale()];
+                                return [$file->getProjectId(), $file->getSourceFilePathRelativeToProject(), $file->getSourceLocale()];
                             },
                             $event->getUploadedFiles()
                         )

--- a/Command/PullCommand.php
+++ b/Command/PullCommand.php
@@ -19,6 +19,7 @@ class PullCommand extends Command
     {
         $this->setName($this->getCommandName())
             ->setDescription($this->getCommandDescription())
+            ->addOption('projectId', null, InputOption::VALUE_OPTIONAL, 'Project Id')
             ->addOption('filePath', 'dir', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'File paths', [])
             ->addOption(
                 'locale',
@@ -46,6 +47,7 @@ class PullCommand extends Command
     {
         $this->handlePullDisplay($output);
         $this->getContainer()->get('openclassrooms.onesky.services.translation_service')->pull(
+            $input->getOption('projectId'),
             $input->getOption('filePath'),
             $input->getOption('locale')
         );

--- a/Command/PushCommand.php
+++ b/Command/PushCommand.php
@@ -19,7 +19,8 @@ class PushCommand extends Command
     {
         $this->setName($this->getCommandName())
             ->setDescription($this->getCommandDescription())
-            ->addOption('filePath', 'dir', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'File path', [])
+            ->addOption('projectId', null, InputOption::VALUE_OPTIONAL, 'Project Id')
+            ->addOption('filePath', 'dir', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'File path ( Project id is required)', [])
             ->addOption(
                 'locale',
                 null,
@@ -46,6 +47,7 @@ class PushCommand extends Command
     {
         $this->handlePushDisplay($output);
         $this->getContainer()->get('openclassrooms.onesky.services.translation_service')->push(
+            $input->getOption('projectId'),
             $input->getOption('filePath'),
             $input->getOption('locale')
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,11 +20,10 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()
             ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('api_secret')->isRequired()->cannotBeEmpty()->end()
-            ->scalarNode('project_id')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('file_format')->cannotBeEmpty()->defaultValue('xliff')->end()
             ->scalarNode('source_locale')->cannotBeEmpty()->defaultValue('en')->end()
             ->arrayNode('locales')->isRequired()->cannotBeEmpty()->prototype('scalar')->end()->end()
-            ->arrayNode('file_paths')->isRequired()->cannotBeEmpty()->prototype('scalar')->end()->end()
+            ->arrayNode('file_paths')->isRequired()->cannotBeEmpty()->prototype('array')->prototype('scalar')->end()->end()->end()
             ->scalarNode('keep_all_strings')->cannotBeEmpty()->defaultValue(true)->end()
             ->end();
 

--- a/DependencyInjection/OpenClassroomsOneSkyExtension.php
+++ b/DependencyInjection/OpenClassroomsOneSkyExtension.php
@@ -27,7 +27,6 @@ class OpenClassroomsOneSkyExtension extends Extension
     {
         $container->setParameter('openclassrooms_onesky.api_key', $config['api_key']);
         $container->setParameter('openclassrooms_onesky.api_secret', $config['api_secret']);
-        $container->setParameter('openclassrooms_onesky.project_id', $config['project_id']);
         $container->setParameter('openclassrooms_onesky.source_locale', $config['source_locale']);
         $container->setParameter('openclassrooms_onesky.locales', $config['locales']);
         $container->setParameter('openclassrooms_onesky.file_format', $config['file_format']);

--- a/Gateways/Impl/LanguageGatewayImpl.php
+++ b/Gateways/Impl/LanguageGatewayImpl.php
@@ -25,24 +25,19 @@ class LanguageGatewayImpl implements LanguageGateway
     private $languageFactory;
 
     /**
-     * @var int
-     */
-    private $projectId;
-
-    /**
      * @return \OpenClassrooms\Bundle\OneSkyBundle\Model\Language[]
      *
      * @throws LanguageException
      * @throws LanguageNotFoundException
      */
-    public function findLanguages(array $locales)
+    public function findLanguages(array $locales, $projectId)
     {
-        $jsonResponse = $this->client->projects(self::LANGUAGES_METHOD, ['project_id' => $this->projectId]);
+        $jsonResponse = $this->client->projects(self::LANGUAGES_METHOD, ['project_id' => $projectId]);
         $response = json_decode($jsonResponse, true);
 
         $this->checkResponse($response, $jsonResponse);
 
-        $languages = $this->createLanguages($response);
+        $languages = $this->createLanguages($response, $projectId);
         $requestedLanguages = [];
         foreach ($locales as $locale) {
             if (isset($languages[$locale])) {
@@ -68,9 +63,9 @@ class LanguageGatewayImpl implements LanguageGateway
     /**
      * @return \OpenClassrooms\Bundle\OneSkyBundle\Model\Language[]
      */
-    private function createLanguages($response)
+    private function createLanguages($response, $projectId)
     {
-        $languages = $this->languageFactory->createFromCollection($response['data']);
+        $languages = $this->languageFactory->createFromCollection($response['data'], $projectId);
 
         return $this->formatLanguages($languages);
     }
@@ -98,10 +93,5 @@ class LanguageGatewayImpl implements LanguageGateway
     public function setLanguageFactory(LanguageFactory $languageFactory)
     {
         $this->languageFactory = $languageFactory;
-    }
-
-    public function setProjectId($projectId)
-    {
-        $this->projectId = $projectId;
     }
 }

--- a/Gateways/LanguageGateway.php
+++ b/Gateways/LanguageGateway.php
@@ -14,5 +14,5 @@ interface LanguageGateway
      *
      * @throws LanguageException
      */
-    public function findLanguages(array $locales);
+    public function findLanguages(array $locales, $projectId);
 }

--- a/Model/File.php
+++ b/Model/File.php
@@ -58,4 +58,13 @@ abstract class File
     {
         return str_replace(DIRECTORY_SEPARATOR, self::FILENAME_SEPARATOR, $this->sourceFilePathRelativeToProject);
     }
+
+
+    /**
+     * @return int
+     */
+    public function getProjectId()
+    {
+        return $this->projectId;
+    }
 }

--- a/Model/FileFactory.php
+++ b/Model/FileFactory.php
@@ -10,10 +10,10 @@ interface FileFactory
     /**
      * @return ExportFile
      */
-    public function createExportFile($sourceFilePath, $requestedLocale);
+    public function createExportFile($sourceFilePath, $projectId, $requestedLocale);
 
     /**
      * @return UploadFile
      */
-    public function createUploadFile($filePath, $locale = null);
+    public function createUploadFile($filePath, $projectId, $locale = null);
 }

--- a/Model/Impl/FileFactoryImpl.php
+++ b/Model/Impl/FileFactoryImpl.php
@@ -21,11 +21,6 @@ class FileFactoryImpl implements FileFactory
     private $kernelRootDir;
 
     /**
-     * @var int
-     */
-    private $projectId;
-
-    /**
      * @var string
      */
     private $sourceLocale;
@@ -38,9 +33,9 @@ class FileFactoryImpl implements FileFactory
     /**
      * @return ExportFile
      */
-    public function createExportFile($sourceFilePath, $requestedLocale)
+    public function createExportFile($sourceFilePath, $projectId, $requestedLocale)
     {
-        return new ExportFileImpl($this->projectId, $sourceFilePath, $this->getProjectDirectory(), $requestedLocale);
+        return new ExportFileImpl($projectId, $sourceFilePath, $this->getProjectDirectory(), $requestedLocale);
     }
 
     /**
@@ -54,10 +49,10 @@ class FileFactoryImpl implements FileFactory
     /**
      * {@inheritdoc}
      */
-    public function createUploadFile($filePath, $locale = null)
+    public function createUploadFile($filePath, $projectId, $locale = null)
     {
         $file =  new UploadFileImpl(
-            $this->projectId,
+            $projectId,
             $filePath,
             $this->getProjectDirectory(),
             $this->fileFormat,
@@ -82,11 +77,6 @@ class FileFactoryImpl implements FileFactory
     public function setKernelRootDir($kernelRootDir)
     {
         $this->kernelRootDir = $kernelRootDir;
-    }
-
-    public function setProjectId($projectId)
-    {
-        $this->projectId = $projectId;
     }
 
     public function setSourceLocale($sourceLocale)

--- a/Model/Impl/LanguageFactoryImpl.php
+++ b/Model/Impl/LanguageFactoryImpl.php
@@ -12,11 +12,11 @@ class LanguageFactoryImpl implements LanguageFactory
     /**
      * {@inheritdoc}
      */
-    public function createFromCollection(array $data)
+    public function createFromCollection(array $data, $projectId)
     {
         $languages = [];
         foreach ($data as $item) {
-            $languages[] = new LanguageImpl($item);
+            $languages[] = new LanguageImpl($item, $projectId);
         }
 
         return $languages;

--- a/Model/Impl/LanguageImpl.php
+++ b/Model/Impl/LanguageImpl.php
@@ -9,9 +9,10 @@ use OpenClassrooms\Bundle\OneSkyBundle\Model\Language;
  */
 class LanguageImpl extends Language
 {
-    public function __construct(array $data)
+    public function __construct(array $data, $projectId)
     {
         $this->locale = $data['locale'];
         $this->translationProgress = $data['translation_progress'];
+        $this->projectId = $projectId;
     }
 }

--- a/Model/Language.php
+++ b/Model/Language.php
@@ -10,6 +10,11 @@ abstract class Language
     /**
      * @var string
      */
+    protected $projectId;
+
+    /**
+     * @var string
+     */
     protected $locale;
 
     /**
@@ -39,5 +44,13 @@ abstract class Language
     public function getTranslationProgress()
     {
         return $this->translationProgress;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProjectId()
+    {
+        return $this->projectId;
     }
 }

--- a/Model/LanguageFactory.php
+++ b/Model/LanguageFactory.php
@@ -10,5 +10,5 @@ interface LanguageFactory
     /**
      * @return Language[]
      */
-    public function createFromCollection(array $data);
+    public function createFromCollection(array $data, $projectId);
 }

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ $bundles = array(
 openclassrooms_onesky:
     api_key:  %onesky.api_key%
     api_secret: %onesky.api_secret%
-    project_id: %onesky.project_id%
     source_locale: %source_locale% #optional, default en
     locales:
       - fr
       - es
     file_format: %onesky.file_format% #optional, default xliff
     file_paths:
-      - %path.to.translations.files.directory%
+        %onesky.project_id%:
+                - %path.to.translations.files.directory%
     keep_all_strings: false # default true
     
 ```

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,9 +24,6 @@
             <call method="setLanguageFactory">
                 <argument type="service" id="openclassrooms.onesky.model.language_factory"/>
             </call>
-            <call method="setProjectId">
-                <argument type="string">%openclassrooms_onesky.project_id%</argument>
-            </call>
         </service>
         <service id="openclassrooms.onesky.model.file_factory" class="OpenClassrooms\Bundle\OneSkyBundle\Model\Impl\FileFactoryImpl">
             <call method="setKeepingAllStrings">
@@ -37,9 +34,6 @@
             </call>
             <call method="setKernelRootDir">
                 <argument type="string">%kernel.root_dir%</argument>
-            </call>
-            <call method="setProjectId">
-                <argument type="string">%openclassrooms_onesky.project_id%</argument>
             </call>
             <call method="setSourceLocale">
                 <argument type="string">%openclassrooms_onesky.source_locale%</argument>

--- a/Services/Impl/LanguageServiceImpl.php
+++ b/Services/Impl/LanguageServiceImpl.php
@@ -23,13 +23,13 @@ class LanguageServiceImpl implements LanguageService
     /**
      * @return \OpenClassrooms\Bundle\OneSkyBundle\Model\Language[]
      */
-    public function getLanguages(array $locales = [])
+    public function getLanguages($projectId, array $locales = [])
     {
         if (empty($locales)) {
             $locales = $this->requestedLocales;
         }
 
-        return $this->languageGateway->findLanguages($locales);
+        return $this->languageGateway->findLanguages($locales, $projectId);
     }
 
     public function setLanguageGateway(LanguageGateway $languageGateway)

--- a/Services/Impl/TranslationServiceImpl.php
+++ b/Services/Impl/TranslationServiceImpl.php
@@ -71,9 +71,11 @@ class TranslationServiceImpl implements TranslationService
     {
         $exportFiles = [];
         /** @var SplFileInfo $file */
-        foreach ($this->getFiles($filePaths, $this->getSourceLocales()) as $file) {
-            foreach ($this->getRequestedLocales($locales) as $locale) {
-                $exportFiles[] = $this->fileFactory->createExportFile($file->getRealPath(), $locale);
+        foreach ($this->getFilePaths($filePaths) as $projectId => &$paths) {
+            foreach ($this->getFiles($paths, $this->getSourceLocales()) as $file) {
+                foreach ($this->getRequestedLocales($locales) as $locale) {
+                    $exportFiles[] = $this->fileFactory->createExportFile($file->getRealPath(), $projectId, $locale);
+                }
             }
         }
 
@@ -95,11 +97,11 @@ class TranslationServiceImpl implements TranslationService
     /**
      * @return Finder
      */
-    private function getFiles(array $filePaths, array $locales)
+    private function getFiles(array $paths, array $locales)
     {
         return Finder::create()
             ->files()
-            ->in($this->getFilePaths($filePaths))
+            ->in($paths)
             ->name('*.{'.implode(',', $locales).'}.'.$this->fileFormat);
     }
 
@@ -135,8 +137,10 @@ class TranslationServiceImpl implements TranslationService
         $uploadFiles = [];
         /* @var SplFileInfo $file */
         foreach ($this->getSourceLocales($locales) as $locale) {
-            foreach ($this->getFiles($filePaths, [$locale]) as $file) {
-                $uploadFiles[] = $this->fileFactory->createUploadFile($file->getRealPath(), $locale);
+            foreach ($filePaths as $projectId => &$paths) {
+                foreach ($this->getFiles($paths, [$locale]) as $file) {
+                    $uploadFiles[] = $this->fileFactory->createUploadFile($file->getRealPath(), $projectId, $locale);
+                }
             }
         }
 

--- a/Services/LanguageService.php
+++ b/Services/LanguageService.php
@@ -10,5 +10,5 @@ interface LanguageService
     /**
      * @return \OpenClassrooms\Bundle\OneSkyBundle\Model\Language[]
      */
-    public function getLanguages(array $locales = []);
+    public function getLanguages($projectId, array $locales = []);
 }

--- a/Services/TranslationService.php
+++ b/Services/TranslationService.php
@@ -11,24 +11,27 @@ use OpenClassrooms\Bundle\OneSkyBundle\Model\UploadFile;
 interface TranslationService
 {
     /**
+     * @param integer $projectId
      * @param string[] $filePaths
      * @param string[] $locales
      *
      * @return ExportFile[] $files
      */
-    public function pull(array $filePaths, array $locales = []);
+    public function pull($projectId, array $filePaths, array $locales = []);
 
     /**
+     * @param integer $projectId
      * @param string[] $filePaths
      *
      * @return UploadFile[] $files
      */
-    public function push(array $filePaths, array $locales = []);
+    public function push($projectId, array $filePaths, array $locales = []);
 
     /**
+     * @param integer $projectId
      * @param string[] $filePaths
      *
      * @return [ExportFile[], UploadFile[]] $files
      */
-    public function update(array $filePaths, array $locales = []);
+    public function update($projectId, array $filePaths, array $locales = []);
 }

--- a/Tests/Command/CommandTestCase.php
+++ b/Tests/Command/CommandTestCase.php
@@ -17,6 +17,10 @@ trait CommandTestCase
      * @var string
      */
     public static $filePaths = 'Tests/Fixtures/Resources/translations';
+    /**
+     * @var integer
+     */
+    public static $projectId = 1;
 
     /**
      * @var string[]

--- a/Tests/Command/CommandTestCase.php
+++ b/Tests/Command/CommandTestCase.php
@@ -24,11 +24,6 @@ trait CommandTestCase
     public static $locales = ['fr'];
 
     /**
-     * @var int
-     */
-    public static $projectId = 1;
-
-    /**
      * @return ContainerInterface
      */
     protected function getContainer()
@@ -37,9 +32,8 @@ trait CommandTestCase
 
         return new ContainerForTest(
             [
-                'openclassrooms_onesky.file_paths' => [self::$filePaths],
+                'openclassrooms_onesky.file_paths' => [ 1 => [self::$filePaths]],
                 'openclassrooms_onesky.requestedLocales' => self::$locales,
-                'openclassrooms_onesky.project_id' => self::$projectId,
                 'kernel.root_dir' => __DIR__.'/../',
             ],
             [

--- a/Tests/Command/PullCommandTest.php
+++ b/Tests/Command/PullCommandTest.php
@@ -51,7 +51,7 @@ class PullCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function with_filePath_execute()
     {
-        $this->commandTester->execute(['command' => PullCommand::COMMAND_NAME, '--filePath' => [self::$filePaths]]);
+        $this->commandTester->execute(['command' => PullCommand::COMMAND_NAME, '--projectId' => [self::$projectId], '--filePath' => [self::$filePaths]]);
         $this->assertEquals([self::$filePaths], TranslationServiceMock::$pulledFilePaths);
     }
 

--- a/Tests/Command/PushCommandTest.php
+++ b/Tests/Command/PushCommandTest.php
@@ -51,7 +51,7 @@ class PushCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function with_filePath_execute()
     {
-        $this->commandTester->execute(['command' => PushCommand::COMMAND_NAME, '--filePath' => [self::$filePaths]]);
+        $this->commandTester->execute(['command' => PushCommand::COMMAND_NAME, '--projectId' => [self::$projectId], '--filePath' => [self::$filePaths]]);
         $this->assertEquals([self::$filePaths], TranslationServiceMock::$pushedFilePaths);
     }
 

--- a/Tests/Doubles/Gateways/InMemoryLanguageGateway.php
+++ b/Tests/Doubles/Gateways/InMemoryLanguageGateway.php
@@ -24,14 +24,14 @@ class InMemoryLanguageGateway implements LanguageGateway
     /**
      * {@inheritdoc}
      */
-    public function findLanguages(array $locales = [])
+    public function findLanguages(array $locales = [], $projectId)
     {
         $languages = [];
         foreach ($locales as $locale) {
-            if (!isset(self::$languages[$locale])) {
+            if (!isset(self::$languages[$projectId][$locale])) {
                 throw new LanguageNotFoundException();
             } else {
-                $languages[] = self::$languages[$locale];
+                $languages[] = self::$languages[$projectId][$locale];
             }
         }
 

--- a/Tests/Doubles/Services/LanguageServiceMock.php
+++ b/Tests/Doubles/Services/LanguageServiceMock.php
@@ -35,11 +35,14 @@ class LanguageServiceMock implements LanguageService
     /**
      * {@inheritdoc}
      */
-    public function getLanguages(array $locales = [])
+    public function getLanguages($projectId, array $locales = [])
     {
         self::$calledGetLanguages = true;
-        self::$locales = $locales;
+        self::$locales[$projectId] = $locales;
 
-        return self::$languages;
+        if(isset(self::$languages[$projectId]))
+            return self::$languages[$projectId];
+        else
+            return array();
     }
 }

--- a/Tests/Doubles/Services/TranslationServiceMock.php
+++ b/Tests/Doubles/Services/TranslationServiceMock.php
@@ -73,7 +73,7 @@ class TranslationServiceMock implements TranslationService
     /**
      * {@inheritdoc}
      */
-    public function pull(array $filePaths, array $locales = [])
+    public function pull($projectId, array $filePaths, array $locales = [])
     {
         $this->eventDispatcher->dispatch(
             TranslationPrePullEvent::getEventName(),
@@ -88,14 +88,14 @@ class TranslationServiceMock implements TranslationService
             new TranslationPostPullEvent([new ExportFileStub1()])
         );
         self::$pullCalled = true;
-        self::$pulledFilePaths = $filePaths;
+        self::$pulledFilePaths = array($projectId => $filePaths);
         self::$locales = $locales;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function push(array $filePaths, array $locales = [])
+    public function push($projectId, array $filePaths, array $locales = [])
     {
         $this->eventDispatcher->dispatch(
             TranslationPrePushEvent::getEventName(),
@@ -110,17 +110,17 @@ class TranslationServiceMock implements TranslationService
             new TranslationPostPushEvent([new UploadFileStub1()])
         );
         self::$pushCalled = true;
-        self::$pushedFilePaths = $filePaths;
+        self::$pushedFilePaths = array($projectId => $filePaths);
         self::$locales = $locales;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function update(array $filePaths = [], array $locales = [])
+    public function update($projectId, array $filePaths = [], array $locales = [])
     {
         self::$updateCalled = true;
-        self::$updatedFilePaths = $filePaths;
+        self::$updatedFilePaths = array($projectId => $filePaths);
         self::$locales = $locales;
     }
 }

--- a/Tests/Fixtures/Resources/config/config.yml
+++ b/Tests/Fixtures/Resources/config/config.yml
@@ -1,11 +1,13 @@
 openclassrooms_onesky:
     api_key: api_key
     api_secret: api_secret
-    project_id: 1
     file_format: yml
     source_locale: en
     locales:
         - fr
         - es
     file_paths:
-        - /
+        1:
+            - /1/
+        2:
+            - /2/

--- a/Tests/Gateways/Impl/LanguageGatewayImplTest.php
+++ b/Tests/Gateways/Impl/LanguageGatewayImplTest.php
@@ -20,6 +20,8 @@ class LanguageGatewayImplTest extends \PHPUnit_Framework_TestCase
      */
     private $gateway;
 
+    const PROJECT_ID = 1;
+
     /**
      * @test
      * @expectedException \OpenClassrooms\Bundle\OneSkyBundle\Gateways\LanguageException
@@ -27,7 +29,7 @@ class LanguageGatewayImplTest extends \PHPUnit_Framework_TestCase
     public function ApiException_findLanguage_ThrowException()
     {
         ClientMock::$languagesContent = '{"meta": {"status": 400}}';
-        $this->gateway->findLanguages([]);
+        $this->gateway->findLanguages([], self::PROJECT_ID);
     }
 
     /**
@@ -36,7 +38,7 @@ class LanguageGatewayImplTest extends \PHPUnit_Framework_TestCase
      */
     public function NonExistingLanguage_findLanguages_ThrowException()
     {
-        $this->gateway->findLanguages(['fr']);
+        $this->gateway->findLanguages(['fr'], self::PROJECT_ID);
     }
 
     /**
@@ -44,7 +46,7 @@ class LanguageGatewayImplTest extends \PHPUnit_Framework_TestCase
      */
     public function findLanguages()
     {
-        $actualLanguages = $this->gateway->findLanguages([LanguageStub1::LOCALE, LanguageStub2::LOCALE]);
+        $actualLanguages = $this->gateway->findLanguages([LanguageStub1::LOCALE, LanguageStub2::LOCALE], self::PROJECT_ID);
         $expectedLanguages = [new LanguageStub1(), new LanguageStub2()];
         $this->assertEquals(LanguageGateway::LANGUAGES_METHOD, ClientMock::$action);
         $this->assertEquals(['project_id' => 1], ClientMock::$parameters);
@@ -67,6 +69,5 @@ class LanguageGatewayImplTest extends \PHPUnit_Framework_TestCase
         $this->gateway->setClient(new ClientMock());
         ClientMock::$languagesContent = '{"meta": {"status": 200,"record_count": 3},"data": [{"code": "en-US","english_name": "English (United States)","local_name": "English (United States)","locale": "en","region": "US","is_base_language": true,"is_ready_to_publish": true,"translation_progress": "100%","uploaded_at": "2013-10-07T15:27:10+0000","uploaded_at_timestamp": 1381159630},{"code": "ja-JP","english_name": "Japanese","local_name": "日本語","locale": "ja","region": "JP","is_base_language": false,"is_ready_to_publish": true,"translation_progress": "98%","uploaded_at": "2013-10-07T15:27:10+0000","uploaded_at_timestamp": 1381159630},{"code": "ko-KR","english_name": "Korean","local_name": "한국어","locale": "ko","region": "KR","is_base_language": false,"is_ready_to_publish": true,"translation_progress": "56%","uploaded_at": "2013-10-07T15:27:10+0000","uploaded_at_timestamp": 1381159630}]}';
         $this->gateway->setLanguageFactory(new LanguageFactoryImpl());
-        $this->gateway->setProjectId(1);
     }
 }

--- a/Tests/Services/Impl/LanguageServiceImplTest.php
+++ b/Tests/Services/Impl/LanguageServiceImplTest.php
@@ -18,12 +18,14 @@ class LanguageServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     private $service;
 
+    const PROJECT_ID = 1;
+
     /**
      * @test
      */
     public function WithoutLocales_getLanguage()
     {
-        $languages = $this->service->getLanguages();
+        $languages = $this->service->getLanguages(self::PROJECT_ID);
         $this->assertEquals([new LanguageStub2()], $languages);
     }
 
@@ -32,7 +34,7 @@ class LanguageServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function getLanguage()
     {
-        $languages = $this->service->getLanguages([LanguageStub1::LOCALE, LanguageStub2::LOCALE]);
+        $languages = $this->service->getLanguages(self::PROJECT_ID, [LanguageStub1::LOCALE, LanguageStub2::LOCALE]);
         $this->assertEquals([new LanguageStub1(), new LanguageStub2()], $languages);
     }
 

--- a/Tests/Services/Impl/TranslationServiceImplTest.php
+++ b/Tests/Services/Impl/TranslationServiceImplTest.php
@@ -19,8 +19,8 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
     const FILE_FORMAT = 'yml';
     const KERNEL_ROOT_DIR = __DIR__.'/../../';
     const PROJECT_DIRECTORY = __DIR__.'/../../../';
-    const PROJECT_ID = 1;
     const SOURCE_LOCALE = 'en';
+    const PROJECT_ID = 1;
 
     /**
      * @var TranslationService
@@ -32,7 +32,7 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function pull_with_locales()
     {
-        $this->service->pull([__DIR__.'/../../Fixtures/Resources/translations'], ['es']);
+        $this->service->pull([self::PROJECT_ID => [__DIR__.'/../../Fixtures/Resources/translations']], ['es']);
         $this->assertEquals(
             [$this->buildExportFile1es(), $this->buildExportFile2es()],
             FileServiceMock::$downloadedFiles
@@ -109,7 +109,7 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function pull()
     {
-        $this->service->pull([__DIR__.'/../../Fixtures/Resources/translations/subDirectory']);
+        $this->service->pull([ self::PROJECT_ID => [__DIR__.'/../../Fixtures/Resources/translations/subDirectory']]);
         $this->assertEquals(
             [
                 $this->buildExportFile2fr(),
@@ -124,7 +124,7 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function WithoutFilePath_push()
     {
-        $this->service->push([]);
+        $this->service->push([self::PROJECT_ID => []]);
         $this->assertEquals([$this->buildUploadFile1(), $this->buildUploadFile2()], FileServiceMock::$uploadedFiles);
     }
 
@@ -167,7 +167,7 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function push()
     {
-        $this->service->push([__DIR__.'/../../Fixtures/Resources/*']);
+        $this->service->push([ self::PROJECT_ID => [__DIR__.'/../../Fixtures/Resources/*']]);
         $this->assertEquals([$this->buildUploadFile1(), $this->buildUploadFile2()], FileServiceMock::$uploadedFiles);
     }
 
@@ -176,7 +176,7 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
      */
     public function WithLocales_update_Update()
     {
-        $this->service->update([__DIR__.'/../../Fixtures/Resources/'], ['es']);
+        $this->service->update([self::PROJECT_ID => [__DIR__.'/../../Fixtures/Resources/']], ['es']);
         $this->assertEquals(
             [$this->buildExportFile1es(), $this->buildExportFile2es()],
             FileServiceMock::$downloadedFiles
@@ -194,7 +194,6 @@ class TranslationServiceImplTest extends \PHPUnit_Framework_TestCase
         $fileFactory->setKeepingAllStrings(self::IS_KEEPING_ALL_STRINGS);
         $fileFactory->setFileFormat(self::FILE_FORMAT);
         $fileFactory->setKernelRootDir(self::KERNEL_ROOT_DIR);
-        $fileFactory->setProjectId(self::PROJECT_ID);
         $fileFactory->setSourceLocale(self::SOURCE_LOCALE);
         $this->service->setEventDispatcher(new EventDispatcher());
         $this->service->setFileFactory($fileFactory);


### PR DESCRIPTION
Hi, 

I updated this project because we some specific needs.
We have one Symphony project, and we need to send translations in more than one OneSky's projects.
So here is the solution I provide : 
I updated the config like that : 

    file_paths:
        123:
            - "%kernel.root_dir%/Resources/translations"
        456:
            - "%kernel.root_dir%/Resources/entities-translations"

With this modifications, we set a project id for one (or more) paths and it upload files directly on good projects.

In addition, I add to the commands a optional "projectId" for the commands (which is needed when you set filePath option ) : 
If you set only filePath, as he don't know his project id, he pull or push every files from every projects
If you only set projectId, he pulls (or push) every files from (to) the wanted project.
If you set filePath and projectId, he pulls (or push) files to (from) folders given from (to) the wanted project.