### PR TITLE
Complex YAML bridge for symfony

### DIFF
--- a/Gateways/Impl/FileGatewayImpl.php
+++ b/Gateways/Impl/FileGatewayImpl.php
@@ -12,6 +12,7 @@ use OpenClassrooms\Bundle\OneSkyBundle\Gateways\NonExistingTranslationException;
 use OpenClassrooms\Bundle\OneSkyBundle\Model\ExportFile;
 use OpenClassrooms\Bundle\OneSkyBundle\Model\UploadFile;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Yaml\Yaml as SFYaml;
 
 /**
  * @author Romain Kuzniak <romain.kuzniak@openclassrooms.com>
@@ -58,7 +59,14 @@ class FileGatewayImpl implements FileGateway
         );
         $downloadedContent = $this->client->translations(self::DOWNLOAD_METHOD, $file->format());
         $this->checkTranslation($downloadedContent, $file);
-        file_put_contents($file->getTargetFilePath(), $downloadedContent);
+        if(!empty($downloadedContent)) {
+            if (is_callable("yaml_parse"))
+                file_put_contents($file->getTargetFilePath(), SFYaml::dump(yaml_parse($downloadedContent)));
+            else
+                throw new HttpException(500, "PHP YAML extension is missing ( https://pecl.php.net/package/yaml )");
+        }
+        else
+            file_put_contents($file->getTargetFilePath(), $downloadedContent);
 
         return $file;
     }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ or by adding the package to the composer.json file directly:
 }
 ```
 
+This bundle need the YAML extension : https://pecl.php.net/package/yaml
+
+#### PHP 7
+```
+apt-get install php-pear libyaml-dev
+pecl install yaml-2.0.0
+```
+Add "extension=yaml.so" to php.ini for CLI
+
+#### PHP 5
+```
+apt-get install php-pear libyaml-dev
+pecl install yaml
+```
+Add "extension=yaml.so" to php.ini for CLI
+
+
+
 After the package has been installed, add the bundle to the AppKernel.php file:
 ```php
 // in AppKernel::registerBundles()


### PR DESCRIPTION
OneSky API export YML files as "complex yaml" when  there's more than one deepness level.
Symfony has it's own YAML implementation that does not accept complex YAML

As PHP has an yml extension which understand complex YAML and can load it as a PHP array, my solution is to load our files with PHP parser and to export it with Symfony's yaml parser.

As understanding complex YAML files is a new feature, I doubt that SensioLab would update their old versions (even maintained versions), so I think the better version is to handle the problem with this bundle as it is the one woe makes a bridge between those two formats

Also, I think test wouldn't appreciate this modification as they wouldn't have yaml extension, but there is multiple composer pull requests to handle pecl extensions, but none seems to have been merged.