### PR TITLE
Use requiresAtLeastOneElement() instead of cannotBeEmpty()

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,8 +23,8 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('project_id')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('file_format')->cannotBeEmpty()->defaultValue('xliff')->end()
             ->scalarNode('source_locale')->cannotBeEmpty()->defaultValue('en')->end()
-            ->arrayNode('locales')->isRequired()->cannotBeEmpty()->prototype('scalar')->end()->end()
-            ->arrayNode('file_paths')->isRequired()->cannotBeEmpty()->prototype('scalar')->end()->end()
+            ->arrayNode('locales')->requiresAtLeastOneElement()->cannotBeEmpty()->prototype('scalar')->end()->end()
+            ->arrayNode('file_paths')->requiresAtLeastOneElement()->cannotBeEmpty()->prototype('scalar')->end()->end()
             ->scalarNode('keep_all_strings')->cannotBeEmpty()->defaultValue(true)->end()
             ->end();
 


### PR DESCRIPTION
Symfony deprecation
https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php#L428