### PR TITLE
Symfony Deprecation Warning

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,8 +23,8 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('project_id')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('file_format')->cannotBeEmpty()->defaultValue('xliff')->end()
             ->scalarNode('source_locale')->cannotBeEmpty()->defaultValue('en')->end()
-            ->arrayNode('locales')->requiresAtLeastOneElement()->cannotBeEmpty()->prototype('scalar')->end()->end()
-            ->arrayNode('file_paths')->requiresAtLeastOneElement()->cannotBeEmpty()->prototype('scalar')->end()->end()
+            ->arrayNode('locales')->requiresAtLeastOneElement()->prototype('scalar')->end()->end()
+            ->arrayNode('file_paths')->requiresAtLeastOneElement()->prototype('scalar')->end()->end()
             ->scalarNode('keep_all_strings')->cannotBeEmpty()->defaultValue(true)->end()
             ->end();
 


### PR DESCRIPTION
Warning:
Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path "openclassrooms_onesky.file_paths" has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.

https://github.com/symfony/config/blob/3.4/Definition/Builder/ArrayNodeDefinition.php#L416